### PR TITLE
Update av-snapshot-mritems.txt (Cup of 13s)

### DIFF
--- a/RELEASE/data/av-snapshot-mritems.txt
+++ b/RELEASE/data/av-snapshot-mritems.txt
@@ -299,6 +299,6 @@
 299	i	wrapped Baseball Diamond	Baseball Diamond	-	-	-	-	-
 300	i	pasta wand loot box	legendary pasta wand	-	-	-	-	-
 301	f	scabbarded Sword of S Words	Sword of S Words	-	-	-	-	-
-302	i	shrink-wrapped Cup of 13s	Cup of 13	-	-	-	-	-
+302	i	shrink-wrapped Cup of 13s	Cup of 13s	-	-	-	-	-
 303	i	packaged Portable Laughing Stock	Portable Laughing Stock	-	-	-	-	-
 304	i	Interesting Coin Inheritance Letter	Interesting Coin	-	-	-	-	-


### PR DESCRIPTION
Update detection for opened Cup of 13s by changing "Cup of 13" to "Cup of 13s".  

I tried updating the local file and it improved detection (Previously did not show green, now shows green)